### PR TITLE
Change the verification request for audd.io

### DIFF
--- a/pkg/detectors/audd/audd.go
+++ b/pkg/detectors/audd/audd.go
@@ -49,7 +49,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api.audd.io/setCallbackUrl/?api_token=%s&url=https://yourwebsite.com/callbacks_handler/", resMatch), nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api.audd.io/getStreamWidgetUrl/?api_token=%s", resMatch), nil)
 			if err != nil {
 				continue
 			}

--- a/pkg/detectors/audd/audd.go
+++ b/pkg/detectors/audd/audd.go
@@ -49,7 +49,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api.audd.io/getStreamWidgetUrl/?api_token=%s", resMatch), nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api.audd.io/getStreamWidgetUrl/?api_token=%s&radio_id=1", resMatch), nil)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
Please change the verification request to the one that wouldn't cause changes to where we send the data (which would lead to the token owner losing that data). The getStreamWidgetUrl would work for all tokens, including the ones generated through our APIs that can be prohibited from accessing the setCallbackUrl method. getStreamWidgetUrl is always guaranteed to work if a functioning token is used.